### PR TITLE
document as and render incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ export default function App() {
 | `name`    | `string`                                              |    ✓     | Associated field name.                                                                                                                                                                    |
 | `errors`  | `object`                                              |          | `errors` object from React Hook Form. It's optional if you are using `FormProvider`.                                                                                                      |
 | `message` | `string \| React.ReactElement`                        |          | inline error message.                                                                                                                                                                     |
-| `as`      | `string \| React.ReactElement \| React.ComponentType` |          | Wrapper component or HTML tag. eg: `as="p"`, `as={<p />}` or `as={CustomComponent}`                                                                                                       |
+| `as`      | `string \| React.ReactElement \| React.ComponentType` |          | Wrapper component or HTML tag. eg: `as="p"`, `as={<p />}` or `as={CustomComponent}`. This prop is incompatible with prop `render` and will take precedence over it.                    |
 | `render`  | `Function`                                            |          | This is a [render prop](https://reactjs.org/docs/render-props.html) for rendering error message or messages. <br><b>Note:</b> you need to set `criteriaMode` to `all` for using messages. |
 
 ## Backers


### PR DESCRIPTION
This is the first part of document the incompatibility between `as` and `render` props, because in `react-hook-form@v6` they are mutually exclusive, with precedence in `as` prop.

Reference: https://github.com/react-hook-form/error-message/issues/14